### PR TITLE
Discord auth

### DIFF
--- a/src/authorize.test.ts
+++ b/src/authorize.test.ts
@@ -18,15 +18,13 @@ test.before(() => {
 	get = sinon.stub(axios, 'get')
 	process.env.CHANNEL_ID = 'dummy-channel-id'
 	process.env.ACCESS_TOKEN = 'dummy-access-token'
-	youtubeDataApiUrl = `https://www.googleapis.com/youtube/v3/channels?part=id&mine=true&access_token=${process.env.ACCESS_TOKEN}`
+	youtubeDataApiUrl = `https://discordapp.com/api/users/@me/guilds`
 })
 
 test('Successful authentication.', async (t) => {
-	get.withArgs(youtubeDataApiUrl).resolves({
+	get.withArgs(youtubeDataApiUrl, { headers: { Authorization: "Bearer " + process.env.ACCESS_TOKEN } }).resolves({
 		status: 200,
-		data: {
-			items: [{ id: process.env.CHANNEL_ID }],
-		},
+		data: [{ id: process.env.CHANNEL_ID, owner: true }],
 	})
 	const res = await authorize({
 		message: process.env.CHANNEL_ID,
@@ -36,11 +34,9 @@ test('Successful authentication.', async (t) => {
 })
 
 test('If the user does not send his channel id, the authentication fails.', async (t) => {
-	get.withArgs(youtubeDataApiUrl).resolves({
+	get.withArgs(youtubeDataApiUrl, { headers: { Authorization: "Bearer " + process.env.ACCESS_TOKEN } }).resolves({
 		status: 200,
-		data: {
-			items: [{ id: process.env.CHANNEL_ID }],
-		},
+		data: [{ id: process.env.CHANNEL_ID, owner: true }],
 	})
 	const res = await authorize({
 		message: 'wrong-dummy-channel-id',
@@ -51,25 +47,11 @@ test('If the user does not send his channel id, the authentication fails.', asyn
 
 test('If the access token does not exist, the authentication fails', async (t) => {
 	const wrongToken = 'wrong-dummy-access-token'
-	youtubeDataApiUrl = `https://www.googleapis.com/youtube/v3/channels?part=id&mine=true&access_token=${wrongToken}`
-	get.withArgs(youtubeDataApiUrl).resolves({
+	get.withArgs(youtubeDataApiUrl, { headers: { Authorization: "Bearer " + wrongToken } }).resolves({
 		status: 401,
 		data: {
-			error: {
-				code: 401,
-				message:
-					'Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.',
-				errors: [
-					{
-						message: 'Invalid Credentials',
-						domain: 'global',
-						reason: 'authError',
-						location: 'Authorization',
-						locationType: 'header',
-					},
-				],
-				status: 'UNAUTHENTICATED',
-			},
+			message: '401: Unauthorized',
+			code: 0,
 		},
 	})
 	const res = await authorize({

--- a/src/authorize.test.ts
+++ b/src/authorize.test.ts
@@ -16,7 +16,7 @@ let discordAPIUrl: string
 
 test.before(() => {
 	get = sinon.stub(axios, 'get')
-	process.env.GUILD_ID = 'dummy-channel-id'
+	process.env.GUILD_ID = 'dummy-guild-id'
 	process.env.ACCESS_TOKEN = 'dummy-access-token'
 	discordAPIUrl = `https://discordapp.com/api/users/@me/guilds`
 })
@@ -47,7 +47,7 @@ test('If the user does not send his channel id, the authentication fails.', asyn
 			data: [{ id: process.env.GUILD_ID, owner: true }],
 		})
 	const res = await authorize({
-		message: 'wrong-dummy-channel-id',
+		message: 'wrong-dummy-guild-id',
 		secret: process.env.ACCESS_TOKEN,
 	} as any)
 	t.false(res)

--- a/src/authorize.test.ts
+++ b/src/authorize.test.ts
@@ -12,32 +12,40 @@ let get: sinon.SinonStub<
 	Promise<unknown>
 >
 
-let youtubeDataApiUrl: string
+let discordAPIUrl: string
 
 test.before(() => {
 	get = sinon.stub(axios, 'get')
-	process.env.CHANNEL_ID = 'dummy-channel-id'
+	process.env.GUILD_ID = 'dummy-channel-id'
 	process.env.ACCESS_TOKEN = 'dummy-access-token'
-	youtubeDataApiUrl = `https://discordapp.com/api/users/@me/guilds`
+	discordAPIUrl = `https://discordapp.com/api/users/@me/guilds`
 })
 
 test('Successful authentication.', async (t) => {
-	get.withArgs(youtubeDataApiUrl, { headers: { Authorization: "Bearer " + process.env.ACCESS_TOKEN } }).resolves({
-		status: 200,
-		data: [{ id: process.env.CHANNEL_ID, owner: true }],
-	})
+	get
+		.withArgs(discordAPIUrl, {
+			headers: { Authorization: 'Bearer ' + process.env.ACCESS_TOKEN },
+		})
+		.resolves({
+			status: 200,
+			data: [{ id: process.env.GUILD_ID, owner: true }],
+		})
 	const res = await authorize({
-		message: process.env.CHANNEL_ID,
+		message: process.env.GUILD_ID,
 		secret: process.env.ACCESS_TOKEN,
 	} as any)
 	t.true(res)
 })
 
 test('If the user does not send his channel id, the authentication fails.', async (t) => {
-	get.withArgs(youtubeDataApiUrl, { headers: { Authorization: "Bearer " + process.env.ACCESS_TOKEN } }).resolves({
-		status: 200,
-		data: [{ id: process.env.CHANNEL_ID, owner: true }],
-	})
+	get
+		.withArgs(discordAPIUrl, {
+			headers: { Authorization: 'Bearer ' + process.env.ACCESS_TOKEN },
+		})
+		.resolves({
+			status: 200,
+			data: [{ id: process.env.GUILD_ID, owner: true }],
+		})
 	const res = await authorize({
 		message: 'wrong-dummy-channel-id',
 		secret: process.env.ACCESS_TOKEN,
@@ -47,15 +55,19 @@ test('If the user does not send his channel id, the authentication fails.', asyn
 
 test('If the access token does not exist, the authentication fails', async (t) => {
 	const wrongToken = 'wrong-dummy-access-token'
-	get.withArgs(youtubeDataApiUrl, { headers: { Authorization: "Bearer " + wrongToken } }).resolves({
-		status: 401,
-		data: {
-			message: '401: Unauthorized',
-			code: 0,
-		},
-	})
+	get
+		.withArgs(discordAPIUrl, {
+			headers: { Authorization: 'Bearer ' + wrongToken },
+		})
+		.resolves({
+			status: 401,
+			data: {
+				message: '401: Unauthorized',
+				code: 0,
+			},
+		})
 	const res = await authorize({
-		message: process.env.CHANNEL_ID,
+		message: process.env.GUILD_ID,
 		secret: 'wrong-dummy-access-token',
 	} as any)
 	t.false(res)

--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -6,21 +6,20 @@ export const authorize: FunctionAuthorizer = async ({ message, secret }) => {
 	return postViewerPermission(message, secret)
 }
 
-type YoutubeAPIResponse = Array<{
-	id: string,
-	owner: boolean,
+type DiscordAPIResponse = ReadonlyArray<{
+	readonly id: string
+	readonly owner: boolean
 }>
 
 async function postViewerPermission(
-	channelId: string,
+	guildId: string,
 	token: string
 ): Promise<boolean> {
 	const res = await post(token)
-	let result = !Array.isArray(res)
+	const result = !Array.isArray(res)
 		? []
-		:
-		res.filter(function (value: { id: string }) {
-			return value.id === channelId;
+		: res.filter(function (value: { readonly id: string }) {
+			return value.id === guildId
 		})
 
 	return res instanceof Error
@@ -32,10 +31,10 @@ async function postViewerPermission(
 			: false
 }
 
-async function post(token: string): Promise<YoutubeAPIResponse | Error> {
-	const youtubeDataApiUrl = `https://discordapp.com/api/users/@me/guilds`
+async function post(token: string): Promise<DiscordAPIResponse | Error> {
+	const discordAPIUrl = `https://discordapp.com/api/users/@me/guilds`
 	return axios
-		.get(youtubeDataApiUrl, { headers: { Authorization: "Bearer " + token } })
+		.get(discordAPIUrl, { headers: { Authorization: 'Bearer ' + token } })
 		.then((response) => response.data)
 		.catch((err: Error) => err)
 }

--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -1,32 +1,41 @@
 import axios from 'axios'
 import { FunctionAuthorizer } from '@devprotocol/khaos-core'
+import { unless } from 'ramda'
 
 export const authorize: FunctionAuthorizer = async ({ message, secret }) => {
 	return postViewerPermission(message, secret)
 }
 
-type YoutubeAPIResponse = {
-	readonly items: readonly [{ readonly id: string }]
-}
+type YoutubeAPIResponse = Array<{
+	id: string,
+	owner: boolean,
+}>
 
 async function postViewerPermission(
 	channelId: string,
 	token: string
 ): Promise<boolean> {
 	const res = await post(token)
+	let result = !Array.isArray(res)
+		? []
+		:
+		res.filter(function (value: { id: string }) {
+			return value.id === channelId;
+		})
+
 	return res instanceof Error
 		? false
-		: res.items
-		? res.items[0].id === channelId
-			? true
+		: result.length > 0
+			? result[0].owner === true
+				? true
+				: false
 			: false
-		: false
 }
 
 async function post(token: string): Promise<YoutubeAPIResponse | Error> {
-	const youtubeDataApiUrl = `https://www.googleapis.com/youtube/v3/channels?part=id&mine=true&access_token=${token}`
+	const youtubeDataApiUrl = `https://discordapp.com/api/users/@me/guilds`
 	return axios
-		.get(youtubeDataApiUrl)
+		.get(youtubeDataApiUrl, { headers: { Authorization: "Bearer " + token } })
 		.then((response) => response.data)
 		.catch((err: Error) => err)
 }

--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -19,16 +19,16 @@ async function postViewerPermission(
 	const result = !Array.isArray(res)
 		? []
 		: res.filter(function (value: { readonly id: string }) {
-			return value.id === guildId
-		})
+				return value.id === guildId
+		  })
 
 	return res instanceof Error
 		? false
 		: result.length > 0
-			? result[0].owner === true
-				? true
-				: false
+		? result[0].owner === true
+			? true
 			: false
+		: false
 }
 
 async function post(token: string): Promise<DiscordAPIResponse | Error> {


### PR DESCRIPTION
This repo is made from https://github.com/dev-protocol/khaos-youtube-market

## Aurhoize
Authorize uses this api: https://discord.com/developers/docs/resources/user#get-current-user-guilds

```
GET/users/@me/guilds
Returns a list of partial guild objects the current user is a member of. Requires the guilds OAuth2 scope.
```

Example of response
```
[
  {
    "id": "80351110224678912",
    "name": "1337 Krew",
    "icon": "8342729096ea3675442027381ff50dfe",
    "owner": false,
    "permissions": "36953089",
    "features": ["COMMUNITY", "NEWS"]
  },
  {
    "id": "932642226142576651",
    "name": "ikeda's server",
    "icon": null,
    "owner": true,
    "permissions": 2147483647,
    "features": [],
    "permissions_new": "2199023255551"
  }
]
```

Auth Logic
1. Call `GET/users/@me/guilds`
2. Filter the target guild id from the list
3. Check if `owner` is true